### PR TITLE
[LIMS-1749] Add angular efficiency and suggested tilt to 3D classification

### DIFF
--- a/src/components/spa/classification.test.tsx
+++ b/src/components/spa/classification.test.tsx
@@ -153,6 +153,14 @@ describe("Classification", () => {
     expect(screen.getByText("Angle Distribution")).toBeInTheDocument();
   });
 
+  it("should display angular efficiency and suggested tilt if type is 3d", async () => {
+    renderWithProviders(<Classification autoProcId={1} type='3d' />);
+
+    await screen.findByText("355-1 (1)");
+    expect(screen.getByText("Angular Efficiency:")).toBeInTheDocument();
+    expect(screen.getByText("Suggested Tilt:")).toBeInTheDocument();
+  });
+
   it("should display classification boxes even if selection status is unknown", async () => {
     server.use(
       http.get(

--- a/src/components/spa/classification.tsx
+++ b/src/components/spa/classification.tsx
@@ -19,7 +19,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { client, prependApiUrl } from "utils/api/client";
 import { components } from "schema/main";
 import { parseData } from "utils/generic";
-import { classificationConfig } from "utils/config/parse";
+import { classification3dConfig, classificationConfig } from "utils/config/parse";
 import { ClassificationProps, SortTypes } from "schema/interfaces";
 import { MolstarModal } from "components/molstar/molstarModal";
 import { useQuery } from "@tanstack/react-query";
@@ -108,11 +108,14 @@ const Classification = ({ autoProcId, type = "2d" }: ClassificationProps) => {
 
   const selectedClassInfo = useMemo(() => {
     if (data && data.data && data.data[selectedClass]) {
-      return parseData(data.data[selectedClass], classificationConfig);
+      return parseData(
+        data.data[selectedClass],
+        type === "3d" ? classification3dConfig : classificationConfig
+      );
     }
 
     return {};
-  }, [selectedClass, data]);
+  }, [selectedClass, data, type]);
 
   const angDistImageUrl = useMemo(
     () =>

--- a/src/utils/config/parse.ts
+++ b/src/utils/config/parse.ts
@@ -27,6 +27,15 @@ export const classificationConfig: DataConfig = {
   root: ["particleClassificationId"],
 };
 
+export const classification3dConfig: DataConfig = {
+  ...classificationConfig,
+  include: [
+    ...classificationConfig.include,
+    { name: "angularEfficiency" },
+    { name: "suggestedTilt" },
+  ],
+};
+
 export const recipeTagMap: Record<string, string> = {
   "em-spa-preprocess": "Preprocessing",
   "em-spa-class2d": "2D Classification",

--- a/src/utils/config/parse.ts
+++ b/src/utils/config/parse.ts
@@ -32,7 +32,7 @@ export const classification3dConfig: DataConfig = {
   include: [
     ...classificationConfig.include,
     { name: "angularEfficiency" },
-    { name: "suggestedTilt" },
+    { name: "suggestedTilt", unit: "°"},
   ],
 };
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1749](https://jira.diamond.ac.uk/browse/LIMS-1749)

**Summary**:

Angular efficiency and suggested tilt are now displayed for 3D classes

**Changes**:
- Display angular efficiency and suggested tilt in 3D classes

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi38903/sessions/3/groups/12693213/spa, navigate down to the 3D classification session, check if angular efficiency and suggested tilt are displayed
