### PR TITLE
[LIMS-1750] Display best resolution for refinement programs

### DIFF
--- a/src/components/spa/refine.test.tsx
+++ b/src/components/spa/refine.test.tsx
@@ -24,6 +24,13 @@ describe("SPA Refinement Step", () => {
     expect(screen.getByText("Open 3D Visualisation (C1)")).toBeInTheDocument();
   });
 
+  it("should display best resolution", async () => {
+    renderWithAccordion(<RefinementStep autoProcId={1} />);
+
+    await screen.findByText(/best resolution/i);
+    expect(screen.getByText("3.00 Å")).toBeInTheDocument();
+  });
+
   it("should only render one button if there's only one particle classification group", async () => {
     server.use(
       http.get(

--- a/src/components/spa/refine.tsx
+++ b/src/components/spa/refine.tsx
@@ -55,7 +55,7 @@ const fetchClassData = async (autoProcId: number) => {
       },
       {
         label: "Best Resolution",
-        value: bestResolution.toFixed(2) + " Å",
+        value: bestResolution ? (bestResolution.toFixed(2) + " Å") : "?",
       }
     ],
   };

--- a/src/components/spa/refine.tsx
+++ b/src/components/spa/refine.tsx
@@ -32,7 +32,10 @@ const fetchClassData = async (autoProcId: number) => {
 
   const [bFactorResponse, classResponse] = await Promise.all(promises);
 
-  const firstClass: FullClassification = classResponse.data.items[0];
+  const classes: FullClassification[] = classResponse.data.items;
+  const firstClass = classes[0];
+
+  const bestResolution = Math.min(...classes.map(particleClass => particleClass.estimatedResolution))
 
   return {
     data: bFactorResponse.data.items.map((item: any) => ({
@@ -50,6 +53,10 @@ const fetchClassData = async (autoProcId: number) => {
         label: "B-Factor",
         value: firstClass.bFactorFitLinear ? (2 / firstClass.bFactorFitLinear).toFixed(3) : "?",
       },
+      {
+        label: "Best Resolution",
+        value: bestResolution.toFixed(2) + " Å",
+      }
     ],
   };
 };
@@ -83,7 +90,7 @@ const RefinementStep = ({ autoProcId }: ClassificationProps) => {
         improve on these resolution values.
       </Alert>
       {data ? (
-        <HStack my='1em' w='100%' alignItems='stretch' flexWrap='wrap'>
+        <HStack my='1em' w='100%' flexWrap='wrap'>
           <VStack h='300px' flex='1 0 250px' alignItems='start'>
             <PlotContainer title='3D Refinement'>
               <ScatterPlot
@@ -106,8 +113,8 @@ const RefinementStep = ({ autoProcId }: ClassificationProps) => {
                 />
               ))}
               <Spacer />
-              <Box minWidth='200px'>
-                <InfoGroup info={data.bFactor} cols={3}></InfoGroup>
+              <Box minW="80px">
+                <InfoGroup info={data.bFactor} cols={2}></InfoGroup>
               </Box>
             </HStack>
           </VStack>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -250,6 +250,7 @@ export const handlers = [
         selected: false,
         bFactorFitIntercept: 10,
         bFactorFitLinear: 10,
+        estimatedResolution: 3
       },
       {
         particleClassificationId: 2,
@@ -261,6 +262,7 @@ export const handlers = [
         selected: true,
         bFactorFitIntercept: 10,
         bFactorFitLinear: 10,
+        estimatedResolution: 5
       },
     ];
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1750](https://jira.diamond.ac.uk/browse/LIMS-1750)

**Summary**:

Best (lowest) resolution is now displayed in the refinement step of particle classification

**Changes**:
- Best (lowest) resolution is now displayed in the refinement step of particle classification

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi34172/sessions/20/groups/13207171/spa, click the refinement step, check if the best resolution is displayed

![image](https://github.com/user-attachments/assets/b919803d-33a3-4946-a9eb-6e5c4b3ea51e)

