### PR TITLE
[LIMS-1774] Point to new data collection groups endpoint

### DIFF
--- a/src/loaders/session.test.ts
+++ b/src/loaders/session.test.ts
@@ -18,7 +18,9 @@ describe("Session Data", () => {
       http.get(
         "http://localhost/proposals/:propId/sessions/:visitId",
         () => HttpResponse.json({}, { status: 404 }),
-        { once: true }
+        {
+          once: true,
+        }
       )
     );
     const data = await sessionPageLoader(queryClient)(request, { propId: "1", visitId: "1" });
@@ -29,11 +31,15 @@ describe("Session Data", () => {
 
   it("should return empty list if data collection groups request fails", async () => {
     server.use(
-      http.get("http://localhost/dataGroups", () => HttpResponse.json({}, { status: 404 }), {
-        once: true,
-      })
+      http.get(
+        "http://localhost/proposals/cm1/sessions/1/dataGroups",
+        () => HttpResponse.json({}, { status: 404 }),
+        {
+          once: true,
+        }
+      )
     );
-    const data = await sessionPageLoader(queryClient)(request, { propId: "1", visitId: "1" });
+    const data = await sessionPageLoader(queryClient)(request, { propId: "cm1", visitId: "1" });
 
     expect(data.items).toEqual([]);
   });

--- a/src/loaders/session.ts
+++ b/src/loaders/session.ts
@@ -3,7 +3,7 @@ import { Params } from "react-router";
 import { ParsedSessionReponse } from "schema/interfaces";
 import { components } from "schema/main";
 import { client } from "utils/api/client";
-import { buildEndpoint } from "utils/api/endpoint";
+import { includePage } from "utils/api/endpoint";
 import { parseSessionData } from "utils/api/response";
 import { getUser, UserWithEmail } from "loaders/user";
 
@@ -33,9 +33,8 @@ const getListingData = async (
   page: string,
   search: string
 ) => {
-  const builtEndpoint = buildEndpoint(
-    "dataGroups",
-    params,
+  const builtEndpoint = includePage(
+    `proposals/${params.propId}/sessions/${params.visitId}/dataGroups`,
     parseInt(items),
     parseInt(page),
     search

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -316,7 +316,7 @@ export const handlers = [
     })
   ),
 
-  http.get("http://localhost/dataGroups", ({ request }) => {
+  http.get("http://localhost/proposals/:propId/sessions/:visitId/dataGroups", ({ request }) => {
     const url = new URL(request.url);
     return HttpResponse.json({
       items: withSearch(

--- a/src/utils/api/endpoint.ts
+++ b/src/utils/api/endpoint.ts
@@ -35,8 +35,6 @@ export const buildEndpoint = (
   switch (endpoint) {
     case "sessions":
       return `${builtEndpoint}&proposal=${params.propId}&countCollections=true`;
-    case "dataGroups":
-      return `${builtEndpoint}&proposal=${params.propId}&session=${params.visitId}`;
     case "dataCollections":
       return `dataGroups/${params.groupId}/${builtEndpoint}`;
     case "processingJobs":


### PR DESCRIPTION
**JIRA ticket**: [TICKET-123](https://link.to.jira)

Requires https://github.com/DiamondLightSource/pato-backend/pull/12

**Summary**:

Since the location of the data collection groups endpoint has changed in the backend has changed, we must update the frontend fetch requests accordingly. 

**Changes**:
- Point to new data collection groups endpoint

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi34172/sessions/20, ensure 5 data collection groups are displayed
