### PR TITLE
[LIMS-1797] Display message if no refinement data is present

### DIFF
--- a/src/components/spa/refine.test.tsx
+++ b/src/components/spa/refine.test.tsx
@@ -61,4 +61,21 @@ describe("SPA Refinement Step", () => {
     await screen.findByText("Open 3D Visualisation (C1)");
     expect(screen.getAllByText(/open 3d visualisation/i)).toHaveLength(1);
   });
+
+  it("should display message if no refinement data is available", async () => {
+    server.use(
+      http.get(
+        "http://localhost/autoProc/:procId/classification",
+        () =>
+          HttpResponse.json({
+            items: [],
+          }),
+        { once: true }
+      )
+    );
+
+    renderWithAccordion(<RefinementStep autoProcId={1} />);
+
+    await screen.findByText("Refinement data not found");
+  });
 });


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1797](https://jira.diamond.ac.uk/browse/LIMS-1797)

**Summary**:

Previously, if an empty list of B-factor fit parameters and classification data was returned, then the refinement step would display a skeleton indefinitely. This now displays a proper error message.

**Changes**:
- Display message if no refinement data is present

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/nr30333/sessions/21/groups/15420091/spa, scroll down to "Refinement", click the arrow, check if "refinement data not found" is displayed
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi38903/sessions/3/groups/12693213/spa, open the refinement step the same way, check if data is displayed normally
