### PR TITLE
[LIMS-1820] Display spinner when uploading file

### DIFF
--- a/src/routes/UploadModel.test.tsx
+++ b/src/routes/UploadModel.test.tsx
@@ -13,6 +13,7 @@ vi.mock("react-router", async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => mockUseNavigate,
+    useParams: () => ({ propId: "cm1", visitId: 1 }),
   };
 });
 
@@ -42,7 +43,7 @@ describe("Upload Model", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-    await waitFor(() => expect(mockUseNavigate).toHaveBeenCalledWith(-1));
+    await waitFor(() => expect(mockUseNavigate).toHaveBeenCalledWith("/proposals/cm1/sessions/1"));
   });
 
   it("should display toast if upload fails and server returns error details", async () => {

--- a/src/routes/UploadModel.tsx
+++ b/src/routes/UploadModel.tsx
@@ -1,5 +1,5 @@
 import { Button, Divider, Heading, useToast, VStack, Text, Code } from "@chakra-ui/react";
-import { FormEvent, useCallback } from "react";
+import { FormEvent, useCallback, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 
 import "styles/upload.css";
@@ -8,6 +8,7 @@ import { client } from "utils/api/client";
 export const UploadModelPage = () => {
   const { propId, visitId } = useParams();
   const toast = useToast();
+  const [loading, setLoading] = useState(false);
 
   const navigate = useNavigate();
 
@@ -15,14 +16,17 @@ export const UploadModelPage = () => {
     async (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       const data = new FormData(e.currentTarget);
+
+      setLoading(true);
       const resp = await client.post(
         `proposals/${propId}/sessions/${visitId}/processingModel`,
         data
       );
+      setLoading(false);
 
       if (resp.status === 200) {
         toast({ status: "success", title: "Model successfully uploaded!" });
-        navigate(-1);
+        navigate(`/proposals/${propId}/sessions/${visitId}`);
       } else {
         toast({
           status: "error",
@@ -44,7 +48,7 @@ export const UploadModelPage = () => {
       </Text>
       <form onSubmit={uploadFile} encType='multipart/form-data'>
         <input name='file' data-testid='file-input' type='file' accept='.h5' />
-        <Button w='8em' type='submit'>
+        <Button w='8em' type='submit' loadingText='Uploading' isLoading={loading}>
           Submit
         </Button>
       </form>


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1820](https://jira.diamond.ac.uk/browse/LIMS-1820)

**Summary**:

Display spinner when uploading HDF5 files, as the files can get quite large and processing/uploading takes time. Because of limitations with ReadableStreams, XHR, MSW and JSDom, it would take a bit of work to make a progress bar that displayed the actual progress.

**Changes**:
- Display spinner when uploading file

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/cm40596/sessions/3/upload-model
- Upload a large HDF5 file (>200MB)
- Check if the spinner is displayed

Note that if you're pointing at the actual filesystem, you'll have to go back to the processing folder of the visit and delete the particle picking model you uploaded afterwards.
