### PR TITLE
Fix box size/astigmatism units

### DIFF
--- a/src/components/motion/motion.tsx
+++ b/src/components/motion/motion.tsx
@@ -78,7 +78,7 @@ const motionConfig = {
     { name: "averageMotionPerFrame", label: "Average Motion/Frame", unit: "Å" },
     { name: "imageNumber" },
     { name: ["patchesUsedX", "patchesUsedY"], label: "Patches Used" },
-    { name: ["boxSizeX", "boxSizeY"], label: "Box Size", unit: "μm" },
+    { name: ["boxSizeX", "boxSizeY"], label: "Box Size", unit: "px" },
     { name: ["minResolution", "maxResolution"], label: "Resolution", unit: "Å" },
     { name: ["minDefocus", "maxDefocus"], label: "Defocus", unit: "Å" },
     { name: "amplitudeContrast" },
@@ -166,6 +166,13 @@ const fetchMotionData = async (
     // Estimated defocus is provided in angstroms
     responseData.items[0].CTF.estimatedDefocus = parseFloat(
       (responseData.items[0].CTF.estimatedDefocus * 0.0001).toFixed(3)
+    );
+  }
+
+  if (responseData.items[0].CTF.astigmatism) {
+    // Astigmatism is provided in angstroms, we want it in nm
+    responseData.items[0].CTF.astigmatism = parseFloat(
+      (responseData.items[0].CTF.astigmatism * 0.1).toFixed(3)
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/pato-frontend/issues/16

**Summary**:

Box size was previously displayed in microns, when the value in the database was actually in pixels. Same for astigmatism, as the value in the database is in angstroms. This PR corrects the measurement unit for both.

**Changes**:
- Fix box size/astigmatism measurement units

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi38903/sessions/3/groups/12693213/spa, check if astigmatism is in the order of -20 nm, and box size is displayed in pixels (px)

<img width="402" height="178" alt="image" src="https://github.com/user-attachments/assets/8c4245af-4a19-429f-9e3f-7e6f00b89ebd" />

