### PR TITLE
[LIMS-1729] Display message if user tries to log in with email

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ import { atlasLoader } from "loaders/atlas";
 import AlertPage from "routes/Alert";
 import { groupLoader } from "loaders/group";
 import { TomogramList } from "routes/TomogramList";
+import InvalidUserPage from "routes/InvalidUser";
 
 const Calendar = React.lazy(() => import("routes/Calendar"));
 const About = React.lazy(() => import("routes/About"));
@@ -55,6 +56,11 @@ const router = createBrowserRouter([
         element: <Home />,
         hydrateFallbackElement: <></>,
         loader: sessionLoader(queryClient),
+      },
+      {
+        path: "/invalid-user",
+        element: <InvalidUserPage />,
+        hydrateFallbackElement: <></>,
       },
       {
         path: "/about",

--- a/src/loaders/user.test.ts
+++ b/src/loaders/user.test.ts
@@ -48,12 +48,33 @@ describe("User Data", () => {
     expect(window.location.replace).toBeCalledWith("http://localhost/?otherVal=1234");
   });
 
+  it("should redirect to 'invalid user' page if user is invalid", async () => {
+    window.location.assign = vi.fn();
+
+    server.use(
+      http.get(
+        "http://localhost/auth/user",
+        () =>
+          HttpResponse.json(
+            { detail: "User is not listed or does not have permission to view content" },
+            { status: 401 }
+          ),
+        { once: true }
+      )
+    );
+
+    await getUser();
+    expect(window.location.assign).toBeCalledWith("/invalid-user");
+  });
+
   it("should redirect if redirectOnFail is set", async () => {
     server.use(
       http.get("http://localhost/auth/user", () => HttpResponse.json({}, { status: 401 }), {
         once: true,
       })
     );
+
+    window.location.replace = vi.fn();
 
     await getUser(true);
     expect(window.location.replace).toBeCalledWith(

--- a/src/loaders/user.ts
+++ b/src/loaders/user.ts
@@ -26,6 +26,13 @@ export const getUser = async (redirectOnFail: boolean = false) => {
         name: response.data.givenName,
         email: response.data.email,
       };
+    } else if (
+      response.status === 401 &&
+      window.location.pathname !== "/invalid-user" &&
+      response.data.detail === "User is not listed or does not have permission to view content"
+    ) {
+      window.location.assign("/invalid-user");
+      return null;
     } else if (!redirectOnFail) {
       return null;
     }

--- a/src/routes/InvalidUser.test.tsx
+++ b/src/routes/InvalidUser.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "utils/test-utils";
+import InvalidUserPage from "./InvalidUser";
+
+describe("Invalid User Page", () => {
+  it("should render page", async () => {
+    renderWithProviders(<InvalidUserPage />);
+    expect(screen.getByText("User not recognised")).toBeInTheDocument();
+  });
+});

--- a/src/routes/InvalidUser.tsx
+++ b/src/routes/InvalidUser.tsx
@@ -1,0 +1,23 @@
+import { Box, Heading, Link, Text, VStack } from "@chakra-ui/react";
+
+const InvalidUserPage = () => (
+  <div className='rootContainer'>
+    <Box marginTop={12} className='main'>
+      <VStack h='100%' justifyContent='center'>
+        <Heading color='diamond.800'>User not recognised</Heading>
+        <Text color='diamond.300'>
+          This user could not be recognised. If you have logged in with your email address,{" "}
+          <Link
+            color='diamond.700'
+            href={`${window.ENV.AUTH_URL}logout?redirect_uri=${window.location.href}`}
+          >
+            log out of the SSO provider
+          </Link>{" "}
+          and log in with your FedID.
+        </Text>
+      </VStack>
+    </Box>
+  </div>
+);
+
+export default InvalidUserPage;


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1729](https://jira.diamond.ac.uk/browse/LIMS-1729)

**Summary**:

Previously, if a user tried to log in using their email address, they would be stuck in a login loop. This, instead, points them to a page explaining the nature of the error and what needs to be done to fix it.

**Changes**:
- Display message if user tries to log in with email

**To test**:
- Go to any page, log in with your email address instead of FedID
- Check if you're redirected to `/invalid-user`
