### PR TITLE
[LIMS-1761] Allow user to upload MRC files

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -377,6 +377,10 @@ export const handlers = [
     HttpResponse.json({})
   ),
 
+  http.post("http://localhost/proposals/:propId/sessions/:sessionId/initialModel", () =>
+    HttpResponse.json({})
+  ),
+
   http.get("http://localhost/processingJob/:procJobId/parameters", () =>
     HttpResponse.json({ items: { do_class3d: "1", do_class2d: "0", Cs: "1" } })
   ),


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1761](https://jira.diamond.ac.uk/browse/LIMS-1761)

**Summary**:

To further improve 3D classification models, users should be able to provide a low-res initial model to act as a starting point for building these classes.

This allows users to upload initial models which are dropped in the visit folder.

This requires https://github.com/DiamondLightSource/pato-backend/pull/17

**Changes**:

- Allow user to upload MRC files

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi34108/sessions/28/upload-model (or any current session), try uploading a valid MRC file like [image.mrc.zip](https://github.com/user-attachments/files/22425131/image.mrc.zip), check if the operation was successful
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi34108/sessions/28/upload-model, try uploading a corrupt/invalid file like [broken.mrc.zip](https://github.com/user-attachments/files/22425139/broken.mrc.zip), check if an error is returned

