### PR TITLE
Fix atlas overlay

### DIFF
--- a/src/components/atlas/Atlas.tsx
+++ b/src/components/atlas/Atlas.tsx
@@ -75,8 +75,8 @@ export const Atlas = ({
       {colours ? (
         <ColourChannelDisplay
           itemId={groupId}
-          minHeight='700px'
-          height='700px'
+          minHeight='820px'
+          height='820px'
           colours={colours}
           onLoad={setSvgDimensions}
         />

--- a/src/components/atlas/Atlas.tsx
+++ b/src/components/atlas/Atlas.tsx
@@ -71,13 +71,19 @@ export const Atlas = ({
   }
 
   return (
-    <div className='img-wrapper'>
+    <div className='img-wrapper' style={{ marginBottom: colours ? "6em" : "0" }}>
       {colours ? (
-        <ColourChannelDisplay itemId={groupId} minHeight="700px" height="700px" colours={colours} onLoad={setSvgDimensions} />
+        <ColourChannelDisplay
+          itemId={groupId}
+          minHeight='700px'
+          height='700px'
+          colours={colours}
+          onLoad={setSvgDimensions}
+        />
       ) : (
         <img src={prependApiUrl(`dataGroups/${groupId}/atlas/image`)} alt='Atlas' />
       )}
-      <svg viewBox={viewBoxSize} className='static-png'>
+      <svg viewBox={viewBoxSize} className='static-png' style={{ width: colours ? "95%" : "100%" }}>
         {data.gridSquares &&
           data.gridSquares.map((gridSquare, index) => (
             <rect

--- a/src/components/atlas/Atlas.tsx
+++ b/src/components/atlas/Atlas.tsx
@@ -1,6 +1,6 @@
 import { Heading, VStack, Link } from "@chakra-ui/react";
 import { AtlasResponse } from "loaders/atlas";
-import { SyntheticEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useLoaderData } from "react-router";
 import { components } from "schema/main";
 import { prependApiUrl } from "utils/api/client";

--- a/src/components/atlas/SearchMap.tsx
+++ b/src/components/atlas/SearchMap.tsx
@@ -1,6 +1,6 @@
 import { Divider, Heading, Skeleton, VStack, HStack, useToast } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { SyntheticEvent, useCallback, useState } from "react";
 import { components } from "schema/main";
 import { client, prependApiUrl } from "utils/api/client";
 import "styles/atlas.css";
@@ -62,6 +62,7 @@ const fetchTomograms = async (searchMapId: number | null, scalingFactor: number)
 };
 
 export const SearchMap = ({ searchMapId, scalingFactor }: SearchMapProps) => {
+  const [viewBox, setViewBox] = useState("0 0 512 512");
   const { data, isLoading } = useQuery({
     queryKey: ["searchMapTomograms", searchMapId],
     queryFn: async () => await fetchTomograms(searchMapId, scalingFactor),
@@ -91,6 +92,10 @@ export const SearchMap = ({ searchMapId, scalingFactor }: SearchMapProps) => {
     [navigate, toast]
   );
 
+  const handleLoad = useCallback((e: SyntheticEvent<HTMLImageElement, Event>) => {
+      setViewBox(`0 0 ${e.currentTarget.naturalWidth} ${e.currentTarget.naturalHeight}`);
+  }, [setViewBox])
+
   return (
     <VStack
       display='flex'
@@ -117,9 +122,9 @@ export const SearchMap = ({ searchMapId, scalingFactor }: SearchMapProps) => {
           No tomograms available
         </Heading>
       ) : (
-        <div style={{ width: "100%", overflow: "hidden" }} className='img-wrapper'>
-          <img src={prependApiUrl(`grid-squares/${searchMapId}/image`)} alt='Search Map' />
-          <svg viewBox='0 0 512 800' className='static-png'>
+        <div style={{ width: "100%" }} className='img-wrapper'>
+          <img src={prependApiUrl(`grid-squares/${searchMapId}/image`)} alt='Search Map' onLoad={handleLoad} />
+          <svg viewBox={viewBox} className='static-png'>
             {data.map((item, i) => (
               <rect
                 data-testid={`item-${i}`}

--- a/src/styles/atlas.css
+++ b/src/styles/atlas.css
@@ -1,11 +1,11 @@
 .img-wrapper {
   position: relative;
-  margin-bottom: 6em;
+  display: "flex";
+  flex: "1 0 300px";
 }
 
 .img-wrapper img {
   width: 100%;
-  max-width: 720px;
   align-self: flex-start;
 }
 
@@ -14,5 +14,4 @@
   top: 0;
   left: 0;
   z-index: 1;
-  width: 95%;
 }

--- a/src/styles/atlas.css
+++ b/src/styles/atlas.css
@@ -1,7 +1,7 @@
 .img-wrapper {
   position: relative;
-  display: "flex";
-  flex: "1 0 300px";
+  display: flex;
+  flex: 1 0 300px;
 }
 
 .img-wrapper img {


### PR DESCRIPTION
**Summary**:

This fixes the mismatched SVG overlay for TEM atlas images

**Changes**:
- Fix atlas overlay

**To test**:
- Go to https://ebic-pato-test.diamond.ac.uk/proposals/nt29812/sessions/302/groups/18373554/atlas, check that the overlaid squares are centred on the grid squares
- Repeat for https://ebic-pato-test.diamond.ac.uk/proposals/nt39080/sessions/26/groups/18373695/atlas
- Repeat for https://ebic-pato-test.diamond.ac.uk/proposals/nt29812/sessions/302/groups/18373557/atlas
- Repeat for https://local-oidc-test.diamond.ac.uk:9000/proposals/nt32457/sessions/25/groups/18374702/atlas?gridSquare=2424893&foilHole=25879049 (SPA)
- Repeat for https://local-oidc-test.diamond.ac.uk:9000/proposals/nt29812/sessions/295/groups/18063897/atlas?gridSquare=1543731 (tall search map)
- Repeat for https://local-oidc-test.diamond.ac.uk:9000/proposals/bi40959/sessions/18/groups/18142851/atlas?gridSquare=1557798&hideEmptySearchMaps=true (square search map)
