### PR TITLE
Fix image sizes for non-animated PNGs in CLEM

### DIFF
--- a/src/components/clem/ROI.tsx
+++ b/src/components/clem/ROI.tsx
@@ -28,6 +28,7 @@ export const ClemROIs = ({ gridSquare }: ClemROIsProps) => {
       alignItems='start'
       border='1px solid'
       borderColor='diamond.900'
+      className='apng-viewer'
     >
       <HStack w='100%'>
         <Heading>ROIs</Heading>

--- a/src/styles/atlas.css
+++ b/src/styles/atlas.css
@@ -15,3 +15,7 @@
   left: 0;
   z-index: 1;
 }
+
+.apng-viewer img {
+  width: 100%;
+}


### PR DESCRIPTION
**Summary**:

This fixes wrongly sized images in CLEM ROI views, which were previously too small

**Changes**:
- Fix image sizes for non-animated PNGs in CLEM

**To test**:
- Go to https://ebic-pato-test.diamond.ac.uk/proposals/bi41018/sessions/10/groups/18384479/atlas?gridSquare=2464682, check if the image is sized properly
- Go to https://ebic-pato-test.diamond.ac.uk/proposals/nt29812/sessions/302/groups/18373554/atlas, check that the overlaid squares are centred on the grid squares
- Repeat for https://ebic-pato-test.diamond.ac.uk/proposals/nt39080/sessions/26/groups/18373695/atlas
- Repeat for https://ebic-pato-test.diamond.ac.uk/proposals/nt29812/sessions/302/groups/18373557/atlas
- Repeat for https://ebic-pato-test.diamond.ac.uk:9000/proposals/nt32457/sessions/25/groups/18374702/atlas?gridSquare=2424893&foilHole=25879049 (SPA)
- Repeat for https://ebic-pato-test.diamond.ac.uk:9000/proposals/nt29812/sessions/295/groups/18063897/atlas?gridSquare=1543731 (tall search map)
- Repeat for https://ebic-pato-test.diamond.ac.uk:9000/proposals/bi40959/sessions/18/groups/18142851/atlas?gridSquare=1557798&hideEmptySearchMaps=true (square search map)
