### PR TITLE
[LIMS-1763] Add redirects for B24 soft x-ray experiments

### DIFF
--- a/src/components/clem/ROI.tsx
+++ b/src/components/clem/ROI.tsx
@@ -28,6 +28,7 @@ export const ClemROIs = ({ gridSquare }: ClemROIsProps) => {
       alignItems='start'
       border='1px solid'
       borderColor='diamond.900'
+      className='apng-viewer'
     >
       <HStack w='100%'>
         <Heading>ROIs</Heading>

--- a/src/loaders/group.ts
+++ b/src/loaders/group.ts
@@ -17,6 +17,7 @@ export const groupLoader = async (params: Params<string>) => {
     case "Single Particle":
       return replace("./spa");
     case "Tomography":
+    case "Soft X-Ray Tomography":
       return replace("./tomograms");
     case "Atlas":
       return replace("./atlas");

--- a/src/loaders/session.ts
+++ b/src/loaders/session.ts
@@ -86,6 +86,7 @@ export const handleGroupClicked = (item: Record<string, string | number>) => {
   switch (item.experimentTypeName) {
     case "Single Particle":
       return `groups/${item.dataCollectionGroupId}/spa`;
+    case "Soft X-Ray Tomography":
     case "Tomography":
       return `groups/${item.dataCollectionGroupId}/tomograms/1`;
     case "CLEM":

--- a/src/routes/Calendar.tsx
+++ b/src/routes/Calendar.tsx
@@ -60,7 +60,7 @@ const Calendar = () => {
 
     client
       .safeGet(
-        `sessions?minStartDate=${calendarDates.start}&maxStartDate=${calendarDates.end}&search=m&limit=250`
+        `sessions?minStartDate=${calendarDates.start}&maxStartDate=${calendarDates.end}&limit=250`
       )
       .then((response) => {
         const events: EventInput[] = response.data.items

--- a/src/styles/atlas.css
+++ b/src/styles/atlas.css
@@ -15,3 +15,7 @@
   left: 0;
   z-index: 1;
 }
+
+.apng-viewer img {
+  width: 100%;
+}


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1763](https://jira.diamond.ac.uk/browse/LIMS-1763)

**Summary**:

This adds redirects for soft x-ray experiments, which were not considered previously

**Changes**:

- Add redirects for B24 soft x-ray experiments

**To test**:

(Currently, B24 sessions have no data collections)
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi42032/sessions, click a session with data collection groups, check if you get redirected to the tomogram page if you click a soft x-ray tomography group