### PR TITLE
Add tomography display for soft x-ray tomography

### DIFF
--- a/src/components/atlas/SearchMap.tsx
+++ b/src/components/atlas/SearchMap.tsx
@@ -92,9 +92,12 @@ export const SearchMap = ({ searchMapId, scalingFactor }: SearchMapProps) => {
     [navigate, toast]
   );
 
-  const handleLoad = useCallback((e: SyntheticEvent<HTMLImageElement, Event>) => {
+  const handleLoad = useCallback(
+    (e: SyntheticEvent<HTMLImageElement, Event>) => {
       setViewBox(`0 0 ${e.currentTarget.naturalWidth} ${e.currentTarget.naturalHeight}`);
-  }, [setViewBox])
+    },
+    [setViewBox]
+  );
 
   return (
     <VStack
@@ -123,7 +126,11 @@ export const SearchMap = ({ searchMapId, scalingFactor }: SearchMapProps) => {
         </Heading>
       ) : (
         <div style={{ width: "100%" }} className='img-wrapper'>
-          <img src={prependApiUrl(`grid-squares/${searchMapId}/image`)} alt='Search Map' onLoad={handleLoad} />
+          <img
+            src={prependApiUrl(`grid-squares/${searchMapId}/image`)}
+            alt='Search Map'
+            onLoad={handleLoad}
+          />
           <svg viewBox={viewBox} className='static-png'>
             {data.map((item, i) => (
               <rect

--- a/src/components/clem/ColourChannelDisplay.tsx
+++ b/src/components/clem/ColourChannelDisplay.tsx
@@ -20,7 +20,7 @@ export const ColourChannelDisplay = ({
   onLoad,
   dataType = "atlas",
   height = "70vh",
-  minHeight="790px"
+  minHeight = "790px",
 }: ColourChannelDisplayProps) => {
   const prefix = useMemo(
     () =>
@@ -53,7 +53,7 @@ export const ColourChannelDisplay = ({
     <Box width='100%' h='100%' minH={minHeight} position='relative'>
       <APNGContainer
         onLoad={onLoad}
-        mb="1em"
+        mb='1em'
         height={height}
         minH={minHeight}
         overlap={true}

--- a/src/components/molstar/MolstarTomogram.tsx
+++ b/src/components/molstar/MolstarTomogram.tsx
@@ -1,4 +1,3 @@
-
 import { PluginContext } from "molstar/lib/mol-plugin/context";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { StateObjectSelector } from "molstar/lib/mol-state";

--- a/src/components/tomogram/main.tsx
+++ b/src/components/tomogram/main.tsx
@@ -67,11 +67,10 @@ const tomogramConfig: DataConfig = {
 const sxtConfig: DataConfig = {
   include: [
     { name: "stackFile" },
+    { name: "volumeFile" },
     { name: "minimumTiltAngle", unit: "°" },
     { name: "maximumTiltAngle", unit: "°" },
     { name: "tiltAngleStep", unit: "°" },
-    { name: "volumeFile" },
-    { name: "pixelSpacing" },
   ],
   root: ["dataCollectionId", "tomogramId"],
 };

--- a/src/components/tomogram/main.tsx
+++ b/src/components/tomogram/main.tsx
@@ -206,16 +206,13 @@ const Tomogram = ({
                 </HStack>
                 <Divider />
                 <Grid py={2} templateColumns='repeat(4, 1fr)' gap={2}>
-                  {checkRecipe(recipes[0], procJob) && (
-                    <GridItem colSpan={{ base: 4, md: 2 }}>
+                  <GridItem colSpan={{ base: 4, md: 2 }}>
+                    {checkRecipe(recipes[0], procJob) ? (
                       <InfoGroup info={data.tomogram.info} cols={1} />
-                    </GridItem>
-                  )}
-                  {checkRecipe(recipes[2], procJob) && (
-                    <GridItem colSpan={{ base: 4, md: 2 }}>
+                    ) : (
                       <InfoGroup info={data.sxt.info} cols={1} />
-                    </GridItem>
-                  )}
+                    )}
+                  </GridItem>
                   <GridItem colSpan={{ base: 4, md: 2 }} h='20vh' minH='300px'>
                     <Card h='100%'>
                       <CardHeader>
@@ -321,7 +318,7 @@ const Tomogram = ({
                         </HStack>
                       </CardHeader>
                       <CardBody pt={0}>
-                        {checkRecipe(recipes[0], procJob) && (
+                        {checkRecipe(recipes[0], procJob) ? (
                           <HStack
                             mx='auto'
                             w='auto'
@@ -359,8 +356,7 @@ const Tomogram = ({
                               movieType={null}
                             />
                           </HStack>
-                        )}
-                        {checkRecipe(recipes[2], procJob) && (
+                        ) : (
                           <HStack
                             mx='auto'
                             w='auto'

--- a/src/components/tomogram/main.tsx
+++ b/src/components/tomogram/main.tsx
@@ -60,6 +60,7 @@ const tomogramConfig: DataConfig = {
     { name: "volumeFile" },
     { name: "pixelSpacing" },
     { name: "refinedTiltAxis", unit: "°" },
+    { name: "globalAlignmentQuality" },
   ],
   root: ["dataCollectionId", "tomogramId"],
 };
@@ -68,9 +69,8 @@ const sxtConfig: DataConfig = {
   include: [
     { name: "stackFile" },
     { name: "volumeFile" },
-    { name: "minimumTiltAngle", unit: "°" },
-    { name: "maximumTiltAngle", unit: "°" },
-    { name: "tiltAngleStep", unit: "°" },
+    { name: "globalAlignmentQuality" },
+    { name: "sizeZ", unit: "pixels" },
   ],
   root: ["dataCollectionId", "tomogramId"],
 };

--- a/src/components/tomogram/main.tsx
+++ b/src/components/tomogram/main.tsx
@@ -36,9 +36,21 @@ import { ProcessingTitle } from "components/visualisation/processingTitle";
 import { capitalise, parseData } from "utils/generic";
 import { MdOpenInNew } from "react-icons/md";
 import { useQuery } from "@tanstack/react-query";
+import {tomographyRecipeTagMap} from "utils/config/parse";
 import { ScatterPlot, InfoGroup, ImageCard, BasePoint } from "@diamondlightsource/ui-components";
 import { countDarkImages, fetchMotionData } from "utils/api/queries/motion";
 import { DarkImageCount } from "components/visualisation/DarkImages";
+
+const recipes = Object.keys(tomographyRecipeTagMap);
+
+/**
+ * Check if recipe matches a given recipe type
+ * @param target Target recipe type
+ * @param procJob Processing job to check
+ * @returns boolean
+ */
+const checkRecipe = (target: string, procJob: BaseProcessingJobProps["procJob"]) =>
+  target === procJob.recipe;
 
 const tomogramConfig: DataConfig = {
   include: [
@@ -52,8 +64,21 @@ const tomogramConfig: DataConfig = {
   root: ["dataCollectionId", "tomogramId"],
 };
 
+const sxtConfig: DataConfig = {
+  include: [
+    { name: "stackFile" },
+    { name: "minimumTiltAngle", unit: "°" },
+    { name: "maximumTiltAngle", unit: "°" },
+    { name: "tiltAngleStep", unit: "°" },
+    { name: "volumeFile" },
+    { name: "pixelSpacing" },
+  ],
+  root: ["dataCollectionId", "tomogramId"],
+};
+
 interface FullTomogramData {
   tomogram: TomogramData | null;
+  sxt: TomogramData | null;
   centralSlice: string;
   xyProj: string;
   xzProj: string;
@@ -87,6 +112,7 @@ const TomogramThumbnail = ({
 const fetchTomogramData = async (tomogram: TomogramResponse | null) => {
   let data: FullTomogramData = {
     tomogram: null,
+    sxt: null,
     centralSlice: "",
     xyProj: "",
     xzProj: "",
@@ -99,6 +125,7 @@ const fetchTomogramData = async (tomogram: TomogramResponse | null) => {
     data = {
       ...data,
       tomogram: parseData(tomogram, tomogramConfig) as TomogramData,
+      sxt: parseData(tomogram, sxtConfig) as TomogramData,
       centralSlice: prependApiUrl(`tomograms/${tomogram.tomogramId}/centralSlice`),
       xyProj: prependApiUrl(`tomograms/${tomogram.tomogramId}/projection?axis=xy`),
       xzProj: prependApiUrl(`tomograms/${tomogram.tomogramId}/projection?axis=xz`),
@@ -173,7 +200,7 @@ const Tomogram = ({
             </Box>
           ) : (
             <Grid gap={3} templateColumns={{ base: "", "2xl": "repeat(2, 1fr)" }}>
-              <Box minW='0'>
+              {checkRecipe(recipes[0], procJob) && <Box minW='0'>
                 <HStack>
                   <Heading variant='collection'>Alignment</Heading>
                   {!isMotionLoading && <DarkImageCount count={darkImages} />}
@@ -336,8 +363,156 @@ const Tomogram = ({
                     <ImageCard src={data.xzProj} title='XZ Projection' />
                   </GridItem>
                 </Grid>
-              </Box>
-              <CTF parentId={data.tomogram.tomogramId} parentType='tomograms' />
+              </Box>}
+              {checkRecipe(recipes[1], procJob) && <CTF parentId={data.tomogram.tomogramId} parentType='tomograms' />}
+              {checkRecipe(recipes[2], procJob) && <Box minW='0'>
+                <HStack>
+                  <Heading variant='collection'>Alignment</Heading>
+                </HStack>
+                <Divider />
+                <Grid py={2} templateColumns='repeat(4, 1fr)' gap={2}>
+                  <GridItem colSpan={{ base: 4, md: 2 }}>
+                    <InfoGroup info={data.sxt.info} cols={1} />
+                  </GridItem>
+                  <GridItem colSpan={{ base: 4, md: 2 }} h='20vh' minH='300px'>
+                    <Card h='100%'>
+                      <CardHeader>
+                        <HStack>
+                          <Heading size='sm'>Stacks</Heading>
+                          <Spacer />
+                          <Button
+                            h='25px'
+                            size='sm'
+                            onClick={() => handleOpenTomogram("alignment")}
+                          >
+                            View
+                            <Spacer />
+                            <Icon ml='10px' as={MdOpenInNew}></Icon>
+                          </Button>
+                        </HStack>
+                      </CardHeader>
+                      <CardBody pt={0}>
+                        <HStack
+                          mx='auto'
+                          w='auto'
+                          h='100%'
+                          divider={<Divider orientation='vertical' />}
+                        >
+                          <TomogramThumbnail
+                            key='Alignment'
+                            baseUrl={data.centralSlice}
+                            movieType='alignment'
+                          />
+                          <TomogramThumbnail
+                            key='Unaligned'
+                            baseUrl={data.centralSlice}
+                            movieType='stack'
+                          />
+                        </HStack>
+                      </CardBody>
+                    </Card>
+                  </GridItem>
+                  <GridItem colSpan={4} h='20vh' minH='300px'>
+                    <Card h='100%'>
+                      <CardHeader>
+                        <HStack>
+                          <Heading size='sm'>Central Slice</Heading>
+                          <Spacer />
+                          {isLargeScreen ? (
+                            <>
+                              <Button
+                                h='25px'
+                                size='sm'
+                                onClick={() => handleOpenTomogram("segmented")}
+                              >
+                                View Segmented
+                                <Spacer />
+                                <Icon ml='10px' as={MdOpenInNew}></Icon>
+                              </Button>
+                            </>
+                          ) : (
+                            <>
+                              <Tooltip label='Select tomogram to display' placement='top'>
+                                <Select
+                                  h='25px'
+                                  w='175px'
+                                  size='sm'
+                                  defaultValue='segmented'
+                                  onChange={handleTomogramSelect}
+                                  rounded='md'
+                                  cursor='pointer'
+                                >
+                                  <option value='segmented'>Segmented</option>
+                                </Select>
+                              </Tooltip>
+                              <Button
+                                h='25px'
+                                size='sm'
+                                onClick={() => handleOpenTomogram(selectedTomogram)}
+                              >
+                                View {capitalise(selectedTomogram)}
+                                <Spacer />
+                                <Icon ml='10px' as={MdOpenInNew}></Icon>
+                              </Button>
+                            </>
+                          )}
+
+                          <Button h='25px' size='sm' onClick={() => handleOpenTomogram("denoised")}>
+                            View Denoised
+                            <Spacer />
+                            <Icon ml='10px' as={MdOpenInNew}></Icon>
+                          </Button>
+                        </HStack>
+                      </CardHeader>
+                      <CardBody pt={0}>
+                        <HStack
+                          mx='auto'
+                          w='auto'
+                          h='100%'
+                          divider={<Divider orientation='vertical' />}
+                        >
+                          {isLargeScreen ? (
+                            [
+                              <TomogramThumbnail
+                                key='segmented'
+                                baseUrl={data.centralSlice}
+                                movieType='segmented'
+                              />,
+                            ]
+                          ) : (
+                            <TomogramThumbnail
+                              key={selectedTomogram}
+                              baseUrl={data.centralSlice}
+                              movieType={selectedTomogram}
+                            />
+                          )}
+                          <TomogramThumbnail
+                            key='denoised'
+                            baseUrl={data.centralSlice}
+                            movieType='denoised'
+                          />
+                          <TomogramThumbnail
+                            key='noisy'
+                            baseUrl={data.centralSlice}
+                            movieType={null}
+                          />
+                        </HStack>
+                      </CardBody>
+                    </Card>
+                  </GridItem>
+                  <GridItem colSpan={{ base: 4, md: 1 }} h='22vh' minH='200px'>
+                    <ImageCard src={data.xyProj} title='XY Projection' />
+                  </GridItem>
+                  <GridItem colSpan={{ base: 4, md: 1 }} minW='100%' h='22vh' minH='200px'>
+                    <PlotContainer title='Shift Plot'>
+                      <ScatterPlot data={data.shiftPlot} />
+                    </PlotContainer>
+                  </GridItem>
+                  <GridItem colSpan={{ base: 4, md: 2 }} h='22vh' minH='200px'>
+                    <ImageCard src={data.xzProj} title='XZ Projection' />
+                  </GridItem>
+                </Grid>
+              </Box>}
             </Grid>
           )}
         </AccordionPanel>

--- a/src/components/tomogram/main.tsx
+++ b/src/components/tomogram/main.tsx
@@ -313,7 +313,9 @@ const Tomogram = ({
               <Box minW='0'>
                 <HStack>
                   <Heading variant='collection'>Alignment</Heading>
-                  {!isMotionLoading && <DarkImageCount count={darkImages} />}
+                  {checkRecipe(recipes[0], procJob) && !isMotionLoading && (
+                    <DarkImageCount count={darkImages} />
+                  )}
                 </HStack>
                 <Divider />
                 <Grid py={2} templateColumns='repeat(4, 1fr)' gap={2}>

--- a/src/components/tomogram/main.tsx
+++ b/src/components/tomogram/main.tsx
@@ -36,7 +36,7 @@ import { ProcessingTitle } from "components/visualisation/processingTitle";
 import { capitalise, parseData } from "utils/generic";
 import { MdOpenInNew } from "react-icons/md";
 import { useQuery } from "@tanstack/react-query";
-import {tomographyRecipeTagMap} from "utils/config/parse";
+import { tomographyRecipeTagMap } from "utils/config/parse";
 import { ScatterPlot, InfoGroup, ImageCard, BasePoint } from "@diamondlightsource/ui-components";
 import { countDarkImages, fetchMotionData } from "utils/api/queries/motion";
 import { DarkImageCount } from "components/visualisation/DarkImages";
@@ -199,16 +199,23 @@ const Tomogram = ({
             </Box>
           ) : (
             <Grid gap={3} templateColumns={{ base: "", "2xl": "repeat(2, 1fr)" }}>
-              {checkRecipe(recipes[0], procJob) && <Box minW='0'>
+              <Box minW='0'>
                 <HStack>
                   <Heading variant='collection'>Alignment</Heading>
                   {!isMotionLoading && <DarkImageCount count={darkImages} />}
                 </HStack>
                 <Divider />
                 <Grid py={2} templateColumns='repeat(4, 1fr)' gap={2}>
-                  <GridItem colSpan={{ base: 4, md: 2 }}>
-                    <InfoGroup info={data.tomogram.info} cols={1} />
-                  </GridItem>
+                  {checkRecipe(recipes[0], procJob) && (
+                    <GridItem colSpan={{ base: 4, md: 2 }}>
+                      <InfoGroup info={data.tomogram.info} cols={1} />
+                    </GridItem>
+                  )}
+                  {checkRecipe(recipes[2], procJob) && (
+                    <GridItem colSpan={{ base: 4, md: 2 }}>
+                      <InfoGroup info={data.sxt.info} cols={1} />
+                    </GridItem>
+                  )}
                   <GridItem colSpan={{ base: 4, md: 2 }} h='20vh' minH='300px'>
                     <Card h='100%'>
                       <CardHeader>
@@ -255,15 +262,17 @@ const Tomogram = ({
                           <Spacer />
                           {isLargeScreen ? (
                             <>
-                              <Button
-                                h='25px'
-                                size='sm'
-                                onClick={() => handleOpenTomogram("picked")}
-                              >
-                                View Picked
-                                <Spacer />
-                                <Icon ml='10px' as={MdOpenInNew}></Icon>
-                              </Button>
+                              {checkRecipe(recipes[0], procJob) && (
+                                <Button
+                                  h='25px'
+                                  size='sm'
+                                  onClick={() => handleOpenTomogram("picked")}
+                                >
+                                  View Picked
+                                  <Spacer />
+                                  <Icon ml='10px' as={MdOpenInNew}></Icon>
+                                </Button>
+                              )}
                               <Button
                                 h='25px'
                                 size='sm'
@@ -287,7 +296,9 @@ const Tomogram = ({
                                   cursor='pointer'
                                 >
                                   <option value='segmented'>Segmented</option>
-                                  <option value='picked'>Picked</option>
+                                  {checkRecipe(recipes[0], procJob) && (
+                                    <option value='picked'>Picked</option>
+                                  )}
                                 </Select>
                               </Tooltip>
                               <Button
@@ -310,192 +321,79 @@ const Tomogram = ({
                         </HStack>
                       </CardHeader>
                       <CardBody pt={0}>
-                        <HStack
-                          mx='auto'
-                          w='auto'
-                          h='100%'
-                          divider={<Divider orientation='vertical' />}
-                        >
-                          {isLargeScreen ? (
-                            [
-                              <TomogramThumbnail
-                                key='picked'
-                                baseUrl={data.centralSlice}
-                                movieType='picked'
-                              />,
-                              <TomogramThumbnail
-                                key='segmented'
-                                baseUrl={data.centralSlice}
-                                movieType='segmented'
-                              />,
-                            ]
-                          ) : (
-                            <TomogramThumbnail
-                              key={selectedTomogram}
-                              baseUrl={data.centralSlice}
-                              movieType={selectedTomogram}
-                            />
-                          )}
-                          <TomogramThumbnail
-                            key='denoised'
-                            baseUrl={data.centralSlice}
-                            movieType='denoised'
-                          />
-                          <TomogramThumbnail
-                            key='noisy'
-                            baseUrl={data.centralSlice}
-                            movieType={null}
-                          />
-                        </HStack>
-                      </CardBody>
-                    </Card>
-                  </GridItem>
-                  <GridItem colSpan={{ base: 4, md: 1 }} h='22vh' minH='200px'>
-                    <ImageCard src={data.xyProj} title='XY Projection' />
-                  </GridItem>
-                  <GridItem colSpan={{ base: 4, md: 1 }} minW='100%' h='22vh' minH='200px'>
-                    <PlotContainer title='Shift Plot'>
-                      <ScatterPlot data={data.shiftPlot} />
-                    </PlotContainer>
-                  </GridItem>
-                  <GridItem colSpan={{ base: 4, md: 2 }} h='22vh' minH='200px'>
-                    <ImageCard src={data.xzProj} title='XZ Projection' />
-                  </GridItem>
-                </Grid>
-              </Box>}
-              {checkRecipe(recipes[1], procJob) && <CTF parentId={data.tomogram.tomogramId} parentType='tomograms' />}
-              {checkRecipe(recipes[2], procJob) && <Box minW='0'>
-                <HStack>
-                  <Heading variant='collection'>Alignment</Heading>
-                </HStack>
-                <Divider />
-                <Grid py={2} templateColumns='repeat(4, 1fr)' gap={2}>
-                  <GridItem colSpan={{ base: 4, md: 2 }}>
-                    <InfoGroup info={data.sxt.info} cols={1} />
-                  </GridItem>
-                  <GridItem colSpan={{ base: 4, md: 2 }} h='20vh' minH='300px'>
-                    <Card h='100%'>
-                      <CardHeader>
-                        <HStack>
-                          <Heading size='sm'>Stacks</Heading>
-                          <Spacer />
-                          <Button
-                            h='25px'
-                            size='sm'
-                            onClick={() => handleOpenTomogram("alignment")}
+                        {checkRecipe(recipes[0], procJob) && (
+                          <HStack
+                            mx='auto'
+                            w='auto'
+                            h='100%'
+                            divider={<Divider orientation='vertical' />}
                           >
-                            View
-                            <Spacer />
-                            <Icon ml='10px' as={MdOpenInNew}></Icon>
-                          </Button>
-                        </HStack>
-                      </CardHeader>
-                      <CardBody pt={0}>
-                        <HStack
-                          mx='auto'
-                          w='auto'
-                          h='100%'
-                          divider={<Divider orientation='vertical' />}
-                        >
-                          <TomogramThumbnail
-                            key='Alignment'
-                            baseUrl={data.centralSlice}
-                            movieType='alignment'
-                          />
-                          <TomogramThumbnail
-                            key='Unaligned'
-                            baseUrl={data.centralSlice}
-                            movieType='stack'
-                          />
-                        </HStack>
-                      </CardBody>
-                    </Card>
-                  </GridItem>
-                  <GridItem colSpan={4} h='20vh' minH='300px'>
-                    <Card h='100%'>
-                      <CardHeader>
-                        <HStack>
-                          <Heading size='sm'>Central Slice</Heading>
-                          <Spacer />
-                          {isLargeScreen ? (
-                            <>
-                              <Button
-                                h='25px'
-                                size='sm'
-                                onClick={() => handleOpenTomogram("segmented")}
-                              >
-                                View Segmented
-                                <Spacer />
-                                <Icon ml='10px' as={MdOpenInNew}></Icon>
-                              </Button>
-                            </>
-                          ) : (
-                            <>
-                              <Tooltip label='Select tomogram to display' placement='top'>
-                                <Select
-                                  h='25px'
-                                  w='175px'
-                                  size='sm'
-                                  defaultValue='segmented'
-                                  onChange={handleTomogramSelect}
-                                  rounded='md'
-                                  cursor='pointer'
-                                >
-                                  <option value='segmented'>Segmented</option>
-                                </Select>
-                              </Tooltip>
-                              <Button
-                                h='25px'
-                                size='sm'
-                                onClick={() => handleOpenTomogram(selectedTomogram)}
-                              >
-                                View {capitalise(selectedTomogram)}
-                                <Spacer />
-                                <Icon ml='10px' as={MdOpenInNew}></Icon>
-                              </Button>
-                            </>
-                          )}
-
-                          <Button h='25px' size='sm' onClick={() => handleOpenTomogram("denoised")}>
-                            View Denoised
-                            <Spacer />
-                            <Icon ml='10px' as={MdOpenInNew}></Icon>
-                          </Button>
-                        </HStack>
-                      </CardHeader>
-                      <CardBody pt={0}>
-                        <HStack
-                          mx='auto'
-                          w='auto'
-                          h='100%'
-                          divider={<Divider orientation='vertical' />}
-                        >
-                          {isLargeScreen ? (
-                            [
+                            {isLargeScreen ? (
+                              [
+                                <TomogramThumbnail
+                                  key='picked'
+                                  baseUrl={data.centralSlice}
+                                  movieType='picked'
+                                />,
+                                <TomogramThumbnail
+                                  key='segmented'
+                                  baseUrl={data.centralSlice}
+                                  movieType='segmented'
+                                />,
+                              ]
+                            ) : (
                               <TomogramThumbnail
-                                key='segmented'
+                                key={selectedTomogram}
                                 baseUrl={data.centralSlice}
-                                movieType='segmented'
-                              />,
-                            ]
-                          ) : (
+                                movieType={selectedTomogram}
+                              />
+                            )}
                             <TomogramThumbnail
-                              key={selectedTomogram}
+                              key='denoised'
                               baseUrl={data.centralSlice}
-                              movieType={selectedTomogram}
+                              movieType='denoised'
                             />
-                          )}
-                          <TomogramThumbnail
-                            key='denoised'
-                            baseUrl={data.centralSlice}
-                            movieType='denoised'
-                          />
-                          <TomogramThumbnail
-                            key='noisy'
-                            baseUrl={data.centralSlice}
-                            movieType={null}
-                          />
-                        </HStack>
+                            <TomogramThumbnail
+                              key='noisy'
+                              baseUrl={data.centralSlice}
+                              movieType={null}
+                            />
+                          </HStack>
+                        )}
+                        {checkRecipe(recipes[2], procJob) && (
+                          <HStack
+                            mx='auto'
+                            w='auto'
+                            h='100%'
+                            divider={<Divider orientation='vertical' />}
+                          >
+                            {isLargeScreen ? (
+                              [
+                                <TomogramThumbnail
+                                  key='segmented'
+                                  baseUrl={data.centralSlice}
+                                  movieType='segmented'
+                                />,
+                              ]
+                            ) : (
+                              <TomogramThumbnail
+                                key={selectedTomogram}
+                                baseUrl={data.centralSlice}
+                                movieType={selectedTomogram}
+                              />
+                            )}
+                            <TomogramThumbnail
+                              key='denoised'
+                              baseUrl={data.centralSlice}
+                              movieType='denoised'
+                            />
+                            <TomogramThumbnail
+                              key='noisy'
+                              baseUrl={data.centralSlice}
+                              movieType={null}
+                            />
+                          </HStack>
+                        )}
                       </CardBody>
                     </Card>
                   </GridItem>
@@ -511,7 +409,10 @@ const Tomogram = ({
                     <ImageCard src={data.xzProj} title='XZ Projection' />
                   </GridItem>
                 </Grid>
-              </Box>}
+              </Box>
+              {checkRecipe(recipes[0], procJob) && (
+                <CTF parentId={data.tomogram.tomogramId} parentType='tomograms' />
+              )}
             </Grid>
           )}
         </AccordionPanel>

--- a/src/components/tomogram/main.tsx
+++ b/src/components/tomogram/main.tsx
@@ -108,6 +108,125 @@ const TomogramThumbnail = ({
   </VStack>
 );
 
+const TomogramSlices = ({
+  centralSlice,
+  handleOpenTomogram,
+}: {
+  centralSlice: string;
+  handleOpenTomogram: (type: TomogramMovieTypes) => void;
+}) => (
+  <Card h='100%'>
+    <CardHeader>
+      <HStack>
+        <Heading size='sm'>Central Slice</Heading>
+        <Spacer />
+        <Button h='25px' size='sm' onClick={() => handleOpenTomogram("segmented")}>
+          View Segmented
+          <Spacer />
+          <Icon ml='10px' as={MdOpenInNew}></Icon>
+        </Button>
+        <Button h='25px' size='sm' onClick={() => handleOpenTomogram("denoised")}>
+          View Denoised
+          <Spacer />
+          <Icon ml='10px' as={MdOpenInNew}></Icon>
+        </Button>
+      </HStack>
+    </CardHeader>
+    <CardBody pt={0}>
+      <HStack mx='auto' w='auto' h='100%' divider={<Divider orientation='vertical' />}>
+        <TomogramThumbnail key='segmented' baseUrl={centralSlice} movieType='segmented' />,
+        <TomogramThumbnail key='denoised' baseUrl={centralSlice} movieType='denoised' />
+        <TomogramThumbnail key='noisy' baseUrl={centralSlice} movieType={null} />
+      </HStack>
+    </CardBody>
+  </Card>
+);
+
+const TomogramSlicesHasPicks = ({
+  centralSlice,
+  handleOpenTomogram,
+}: {
+  centralSlice: string;
+  handleOpenTomogram: (type: TomogramMovieTypes) => void;
+}) => {
+  const [selectedTomogram, setSelectedTomogram] = useState<TomogramMovieTypes>("segmented");
+  const [isLargeScreen] = useMediaQuery("(min-width: 1500px)");
+  const handleTomogramSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value as TomogramMovieTypes;
+    setSelectedTomogram(value);
+  };
+  return (
+    <Card h='100%'>
+      <CardHeader>
+        <HStack>
+          <Heading size='sm'>Central Slice</Heading>
+          <Spacer />
+          {isLargeScreen ? (
+            <>
+              <Button h='25px' size='sm' onClick={() => handleOpenTomogram("picked")}>
+                View Picked
+                <Spacer />
+                <Icon ml='10px' as={MdOpenInNew}></Icon>
+              </Button>
+              <Button h='25px' size='sm' onClick={() => handleOpenTomogram("segmented")}>
+                View Segmented
+                <Spacer />
+                <Icon ml='10px' as={MdOpenInNew}></Icon>
+              </Button>
+            </>
+          ) : (
+            <>
+              <Tooltip label='Select tomogram to display' placement='top'>
+                <Select
+                  h='25px'
+                  w='175px'
+                  size='sm'
+                  defaultValue='segmented'
+                  onChange={handleTomogramSelect}
+                  rounded='md'
+                  cursor='pointer'
+                >
+                  <option value='segmented'>Segmented</option>
+                  <option value='segmented'>Picked</option>
+                </Select>
+              </Tooltip>
+              <Button h='25px' size='sm' onClick={() => handleOpenTomogram(selectedTomogram)}>
+                View {capitalise(selectedTomogram)}
+                <Spacer />
+                <Icon ml='10px' as={MdOpenInNew}></Icon>
+              </Button>
+            </>
+          )}
+
+          <Button h='25px' size='sm' onClick={() => handleOpenTomogram("denoised")}>
+            View Denoised
+            <Spacer />
+            <Icon ml='10px' as={MdOpenInNew}></Icon>
+          </Button>
+        </HStack>
+      </CardHeader>
+      <CardBody pt={0}>
+        <HStack mx='auto' w='auto' h='100%' divider={<Divider orientation='vertical' />}>
+          {isLargeScreen ? (
+            [
+              <TomogramThumbnail key='picked' baseUrl={centralSlice} movieType='picked' />,
+              <TomogramThumbnail key='segmented' baseUrl={centralSlice} movieType='segmented' />,
+            ]
+          ) : (
+            <TomogramThumbnail
+              key={selectedTomogram}
+              baseUrl={centralSlice}
+              movieType={selectedTomogram}
+            />
+          )}
+          <TomogramThumbnail key='denoised' baseUrl={centralSlice} movieType='denoised' />
+          <TomogramThumbnail key='noisy' baseUrl={centralSlice} movieType={null} />
+        </HStack>
+      </CardBody>
+    </Card>
+  );
+};
+
 const fetchTomogramData = async (tomogram: TomogramResponse | null) => {
   let data: FullTomogramData = {
     tomogram: null,
@@ -166,20 +285,12 @@ const Tomogram = ({
     return null;
   }, [motion]);
 
-  const [selectedTomogram, setSelectedTomogram] = useState<TomogramMovieTypes>("segmented");
-  const [isLargeScreen] = useMediaQuery("(min-width: 1500px)");
-
   const handleOpenTomogram = useCallback(
     (type: TomogramMovieTypes) => {
       onTomogramOpened(data!.tomogram!.tomogramId, type);
     },
     [data, onTomogramOpened]
   );
-
-  const handleTomogramSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value as TomogramMovieTypes;
-    setSelectedTomogram(value);
-  };
 
   return (
     <AccordionItem isDisabled={false}>
@@ -193,7 +304,7 @@ const Tomogram = ({
               <Skeleton w='100%' h='20vh' />
               <Skeleton w='100%' h='20vh' />
             </VStack>
-          ) : !data || data.tomogram === null ? (
+          ) : !data || data.tomogram === null || data.sxt == null ? (
             <Box>
               <Motion parentId={procJob.dataCollectionId} parentType='tomograms' />
             </Box>
@@ -252,146 +363,17 @@ const Tomogram = ({
                     </Card>
                   </GridItem>
                   <GridItem colSpan={4} h='20vh' minH='300px'>
-                    <Card h='100%'>
-                      <CardHeader>
-                        <HStack>
-                          <Heading size='sm'>Central Slice</Heading>
-                          <Spacer />
-                          {isLargeScreen ? (
-                            <>
-                              {checkRecipe(recipes[0], procJob) && (
-                                <Button
-                                  h='25px'
-                                  size='sm'
-                                  onClick={() => handleOpenTomogram("picked")}
-                                >
-                                  View Picked
-                                  <Spacer />
-                                  <Icon ml='10px' as={MdOpenInNew}></Icon>
-                                </Button>
-                              )}
-                              <Button
-                                h='25px'
-                                size='sm'
-                                onClick={() => handleOpenTomogram("segmented")}
-                              >
-                                View Segmented
-                                <Spacer />
-                                <Icon ml='10px' as={MdOpenInNew}></Icon>
-                              </Button>
-                            </>
-                          ) : (
-                            <>
-                              <Tooltip label='Select tomogram to display' placement='top'>
-                                <Select
-                                  h='25px'
-                                  w='175px'
-                                  size='sm'
-                                  defaultValue='segmented'
-                                  onChange={handleTomogramSelect}
-                                  rounded='md'
-                                  cursor='pointer'
-                                >
-                                  <option value='segmented'>Segmented</option>
-                                  {checkRecipe(recipes[0], procJob) && (
-                                    <option value='picked'>Picked</option>
-                                  )}
-                                </Select>
-                              </Tooltip>
-                              <Button
-                                h='25px'
-                                size='sm'
-                                onClick={() => handleOpenTomogram(selectedTomogram)}
-                              >
-                                View {capitalise(selectedTomogram)}
-                                <Spacer />
-                                <Icon ml='10px' as={MdOpenInNew}></Icon>
-                              </Button>
-                            </>
-                          )}
-
-                          <Button h='25px' size='sm' onClick={() => handleOpenTomogram("denoised")}>
-                            View Denoised
-                            <Spacer />
-                            <Icon ml='10px' as={MdOpenInNew}></Icon>
-                          </Button>
-                        </HStack>
-                      </CardHeader>
-                      <CardBody pt={0}>
-                        {checkRecipe(recipes[0], procJob) ? (
-                          <HStack
-                            mx='auto'
-                            w='auto'
-                            h='100%'
-                            divider={<Divider orientation='vertical' />}
-                          >
-                            {isLargeScreen ? (
-                              [
-                                <TomogramThumbnail
-                                  key='picked'
-                                  baseUrl={data.centralSlice}
-                                  movieType='picked'
-                                />,
-                                <TomogramThumbnail
-                                  key='segmented'
-                                  baseUrl={data.centralSlice}
-                                  movieType='segmented'
-                                />,
-                              ]
-                            ) : (
-                              <TomogramThumbnail
-                                key={selectedTomogram}
-                                baseUrl={data.centralSlice}
-                                movieType={selectedTomogram}
-                              />
-                            )}
-                            <TomogramThumbnail
-                              key='denoised'
-                              baseUrl={data.centralSlice}
-                              movieType='denoised'
-                            />
-                            <TomogramThumbnail
-                              key='noisy'
-                              baseUrl={data.centralSlice}
-                              movieType={null}
-                            />
-                          </HStack>
-                        ) : (
-                          <HStack
-                            mx='auto'
-                            w='auto'
-                            h='100%'
-                            divider={<Divider orientation='vertical' />}
-                          >
-                            {isLargeScreen ? (
-                              [
-                                <TomogramThumbnail
-                                  key='segmented'
-                                  baseUrl={data.centralSlice}
-                                  movieType='segmented'
-                                />,
-                              ]
-                            ) : (
-                              <TomogramThumbnail
-                                key={selectedTomogram}
-                                baseUrl={data.centralSlice}
-                                movieType={selectedTomogram}
-                              />
-                            )}
-                            <TomogramThumbnail
-                              key='denoised'
-                              baseUrl={data.centralSlice}
-                              movieType='denoised'
-                            />
-                            <TomogramThumbnail
-                              key='noisy'
-                              baseUrl={data.centralSlice}
-                              movieType={null}
-                            />
-                          </HStack>
-                        )}
-                      </CardBody>
-                    </Card>
+                    {checkRecipe(recipes[0], procJob) ? (
+                      <TomogramSlicesHasPicks
+                        centralSlice={data.centralSlice}
+                        handleOpenTomogram={handleOpenTomogram}
+                      />
+                    ) : (
+                      <TomogramSlices
+                        centralSlice={data.centralSlice}
+                        handleOpenTomogram={handleOpenTomogram}
+                      />
+                    )}
                   </GridItem>
                   <GridItem colSpan={{ base: 4, md: 1 }} h='22vh' minH='200px'>
                     <ImageCard src={data.xyProj} title='XY Projection' />

--- a/src/components/visualisation/apngContainer.tsx
+++ b/src/components/visualisation/apngContainer.tsx
@@ -94,7 +94,7 @@ const APNGContainer = ({
           <Box
             key={i}
             w={overlap ? "95%" : "100%"}
-            h="100%"
+            h='100%'
             {...(overlap ? { ...OVERLAP_PROPS } : {})}
             opacity={overlap ? (1 / visibleViews) * 1.2 : 1}
             display={view.hidden ? "none" : "block"}

--- a/src/loaders/tomogram.ts
+++ b/src/loaders/tomogram.ts
@@ -2,7 +2,7 @@ import { Params, redirect } from "react-router";
 import { CollectionData } from "schema/interfaces";
 import { client } from "utils/api/client";
 import { includePage } from "utils/api/endpoint";
-import { collectionConfig, tomographyRecipeTagMap } from "utils/config/parse";
+import { collectionConfig, sxtCollectionConfig, tomographyRecipeTagMap } from "utils/config/parse";
 import { parseData } from "utils/generic";
 import { components } from "schema/main";
 import { QueryClient } from "@tanstack/react-query";
@@ -81,7 +81,7 @@ const getTomogramData = async (
 
     returnData.collection = parseData(
       collectionResponse.data.items[0],
-      collectionConfig
+      collectionResponse.data.items[0].voltage ? collectionConfig : sxtCollectionConfig
     ) as CollectionData;
 
     const tomogramsResponse = await client.safeGet(

--- a/src/utils/config/parse.ts
+++ b/src/utils/config/parse.ts
@@ -46,6 +46,7 @@ export const spaRecipeTagMap: Record<string, string> = {
 export const tomographyRecipeTagMap: Record<string, string> = {
   "em-tomo-align": "Alignment",
   "em-tomo-preprocess": "Preprocessing",
+  "sxt-aretomo": "AreTomo",
 };
 
 export const recipeTagMap: Record<string, string> = {

--- a/src/utils/config/parse.ts
+++ b/src/utils/config/parse.ts
@@ -14,6 +14,9 @@ export const sxtCollectionConfig: DataConfig = {
     { name: "pixelSizeOnImage", unit: "Å" },
     { name: "wavelength", unit: "eV" },
     { name: ["imageSizeX", "imageSizeY"], unit: "pixels", label: "Image Size" },
+    { name: "axisStart", unit: "°" },
+    { name: "axisEnd", unit: "°" },
+    { name: "numberOfImages" },
   ],
   root: ["comments", "dataCollectionId", "pixelSizeOnImage"],
 };

--- a/src/utils/config/parse.ts
+++ b/src/utils/config/parse.ts
@@ -11,11 +11,12 @@ export const collectionConfig: DataConfig = {
 
 export const sxtCollectionConfig: DataConfig = {
   include: [
-    { name: "pixelSizeOnImage", unit: "Å" },
+    { name: "pixelSizeNanometers", unit: "nm" },
     { name: "wavelength", unit: "eV" },
     { name: ["imageSizeX", "imageSizeY"], unit: "pixels", label: "Image Size" },
     { name: "axisStart", unit: "°" },
     { name: "axisEnd", unit: "°" },
+    { name: "axisStep", unit: "°" },
     { name: "numberOfImages" },
   ],
   root: ["comments", "dataCollectionId", "pixelSizeOnImage"],

--- a/src/utils/config/parse.ts
+++ b/src/utils/config/parse.ts
@@ -9,6 +9,15 @@ export const collectionConfig: DataConfig = {
   root: ["comments", "dataCollectionId", "pixelSizeOnImage"],
 };
 
+export const sxtCollectionConfig: DataConfig = {
+  include: [
+    { name: "pixelSizeOnImage", unit: "Å" },
+    { name: "wavelength", unit: "eV" },
+    { name: ["imageSizeX", "imageSizeY"], unit: "pixels", label: "Image Size" },
+  ],
+  root: ["comments", "dataCollectionId", "pixelSizeOnImage"],
+};
+
 export const classificationConfig: DataConfig = {
   include: [
     { name: "type" },

--- a/src/utils/molstar.ts
+++ b/src/utils/molstar.ts
@@ -25,7 +25,7 @@ export const DefaultSliceSpec: PluginSpec = {
 
 // This is tested inside the Molstar internals, and there is no benefit to a complex mock for this
 /* c8 ignore start */
-export const resetCameraOrientation = (molstar: PluginContext,isSlice = false) => {
+export const resetCameraOrientation = (molstar: PluginContext, isSlice = false) => {
   // Resets to original orientation (depends on view type)
 
   molstar.canvas3d!.requestCameraReset({


### PR DESCRIPTION
**Summary**:

Add a display for the soft x-ray tomography experiments done at DLS B24. The processing and display is very similar to the existing eBIC tomography view.

**Changes**:
- Adds display for the `sxt-aretomo` recipe type

**To test**:
- Check existing eBIC tomography untouched
- Check b24 tomography
