### PR TITLE
Allow to default to central slice in APNG viewer

### DIFF
--- a/src/components/clem/ColourChannelDisplay.tsx
+++ b/src/components/clem/ColourChannelDisplay.tsx
@@ -54,6 +54,7 @@ export const ColourChannelDisplay = ({
       <APNGContainer
         onLoad={onLoad}
         mb='1em'
+        startFromCentralSlice={true}
         height={height}
         minH={minHeight}
         overlap={true}

--- a/src/components/tomogram/SliceViewer.tsx
+++ b/src/components/tomogram/SliceViewer.tsx
@@ -37,10 +37,7 @@ export const SliceViewer = ({
   tomogramId,
   isOpen = false,
 }: SliceViewerProps) => {
-  const tomogramMovieSrc = useMemo(
-    () => prependApiUrl(`tomograms/${tomogramId}/movie`),
-    [tomogramId]
-  );
+  const tomogramMovieSrc = useMemo(() => prependApiUrl(`tomograms/${tomogramId}/movie`), [tomogramId]);
 
   if (!isOpen) {
     return null;
@@ -55,13 +52,7 @@ export const SliceViewer = ({
         <ModalBody h={{ base: "90vh", md: "60vh" }}>
           <HStack>
             <Spacer />
-            <Flipper
-              size='md'
-              onChangeEnd={onPageChange}
-              defaultPage={page}
-              total={total}
-              w='5em'
-            />
+            <Flipper size='md' onChangeEnd={onPageChange} defaultPage={page} total={total} w='5em' />
           </HStack>
           <Suspense>
             {movieType === "alignment" ? (
@@ -70,9 +61,7 @@ export const SliceViewer = ({
                   <Image
                     h='100%'
                     alt='Stack'
-                    src={prependApiUrl(
-                      `tomograms/${tomogramId}/centralSlice?movieType=${movieType}`
-                    )}
+                    src={prependApiUrl(`tomograms/${tomogramId}/centralSlice?movieType=${movieType}`)}
                     fallbackSrc='/images/no-image.png'
                     objectFit='contain'
                   />
@@ -82,10 +71,12 @@ export const SliceViewer = ({
                 </VStack>
                 <APNGContainer
                   views={[{ src: `${tomogramMovieSrc}?movieType=stack`, caption: "Stack" }]}
+                  startFromCentralSlice={true}
                 />
               </HStack>
             ) : (
               <APNGContainer
+                startFromCentralSlice={true}
                 views={[
                   {
                     src: `${tomogramMovieSrc}?movieType=${movieType}`,

--- a/src/components/visualisation/apngContainer.test.tsx
+++ b/src/components/visualisation/apngContainer.test.tsx
@@ -69,7 +69,15 @@ describe("APNG Container", () => {
     await screen.findByText("tomograms/1/movie");
 
     const slider = screen.getByRole("slider");
-    expect(slider).toHaveAttribute("aria-valuemax", "3");
+    await waitFor(() => expect(slider).toHaveAttribute("aria-valuemax", "3"));
+  });
+
+  it("should select middle frame if that option is selected", async () => {
+    renderWithProviders(<APNGContainer startFromCentralSlice={true} views={[{ src: "tomograms/1/movie" }]} />);
+    await screen.findByText("tomograms/1/movie");
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveValue(1);
   });
 
   it("should hide items tagged with hidden", async () => {

--- a/src/components/visualisation/apngContainer.tsx
+++ b/src/components/visualisation/apngContainer.tsx
@@ -18,7 +18,7 @@ import {
   ButtonGroup,
   BoxProps,
 } from "@chakra-ui/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MdFastForward, MdFastRewind, MdPause, MdPlayArrow } from "react-icons/md";
 import { APNGViewer, ApngProps } from "@diamondlightsource/ui-components";
 import "styles/canvas.css";
@@ -32,6 +32,7 @@ export interface ApngContainerProps extends Omit<BoxProps, "onLoad"> {
   views: ApngView[];
   overlap?: boolean;
   fallbackToPng?: boolean;
+  startFromCentralSlice?: boolean;
   onLoad?: ApngProps["onLoad"];
 }
 
@@ -47,6 +48,7 @@ const APNGContainer = ({
   views,
   overlap = false,
   fallbackToPng,
+  startFromCentralSlice = false,
   onLoad,
   ...props
 }: ApngContainerProps) => {
@@ -76,6 +78,16 @@ const APNGContainer = ({
     return () => clearInterval(playRef.current);
   }, [frameIndex, playing, frametime, frameLength, playIncrement, playForward]);
 
+  const setFrameCount = useCallback(
+    (count: number) => {
+      setFrameLength(count);
+      if (startFromCentralSlice) {
+        setFrameIndex(Math.floor(count / 2));
+      }
+    },
+    [startFromCentralSlice],
+  );
+
   const visibleViews = useMemo(
     () =>
       Object.values(views).reduce((prev, { hidden }) => {
@@ -84,7 +96,7 @@ const APNGContainer = ({
         }
         return prev;
       }, 0),
-    [views]
+    [views],
   );
 
   return (
@@ -104,7 +116,7 @@ const APNGContainer = ({
             <APNGViewer
               onLoad={onLoad}
               key={i}
-              onFrameCountChanged={setFrameLength}
+              onFrameCountChanged={setFrameCount}
               frameIndex={frameIndex}
               caption={view.caption}
               src={view.src}
@@ -141,11 +153,7 @@ const APNGContainer = ({
           >
             <Icon as={MdFastRewind} />
           </Button>
-          <Button
-            aria-label='Play Forwards'
-            isDisabled={playForward}
-            onClick={() => setPlayForward(true)}
-          >
+          <Button aria-label='Play Forwards' isDisabled={playForward} onClick={() => setPlayForward(true)}>
             <Icon as={MdFastForward} />
           </Button>
         </ButtonGroup>


### PR DESCRIPTION
**Changes**:
- Set tomogram/CLEM APNG viewers to default to the central slice

**To test**:
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/nt42531/sessions/12/groups/19010972/atlas, check it defaults to the central slice
