### PR TITLE
Display search maps for SXT, link to search map in tomogram page

### DIFF
--- a/src/routes/Atlas.tsx
+++ b/src/routes/Atlas.tsx
@@ -134,7 +134,7 @@ const AtlasPage = () => {
           selectedGridSquare={gridSquareId}
           colours={data.dataCollectionGroup.experimentTypeName === "CLEM" ? colours : null}
         />
-        {data.dataCollectionGroup.experimentTypeName === "Tomography" ? (
+        {["Tomography", "Soft X-Ray Tomography"].includes(data.dataCollectionGroup.experimentTypeName!) ? (
           <SearchMap searchMapId={gridSquareId} scalingFactor={scalingFactor} />
         ) : data.dataCollectionGroup.experimentTypeName === "CLEM" ? (
           <ClemROIs gridSquare={selectedGridSquare} />

--- a/src/routes/Atlas.tsx
+++ b/src/routes/Atlas.tsx
@@ -134,7 +134,7 @@ const AtlasPage = () => {
           selectedGridSquare={gridSquareId}
           colours={data.dataCollectionGroup.experimentTypeName === "CLEM" ? colours : null}
         />
-        {["Tomography", "Soft X-Ray Tomography"].includes(data.dataCollectionGroup.experimentTypeName!) ? (
+        {["Tomography", "Lamella Tomography", "Soft X-Ray Tomography"].includes(data.dataCollectionGroup.experimentTypeName!) ? (
           <SearchMap searchMapId={gridSquareId} scalingFactor={scalingFactor} />
         ) : data.dataCollectionGroup.experimentTypeName === "CLEM" ? (
           <ClemROIs gridSquare={selectedGridSquare} />

--- a/src/routes/Tomogram.tsx
+++ b/src/routes/Tomogram.tsx
@@ -159,11 +159,16 @@ const TomogramPage = () => {
                 <Button
                   aria-label='View Atlas'
                   as={Link}
-                  to={{ pathname: "../../atlas" }}
+                  to={{ 
+                    pathname: "../../atlas", 
+                    /* If there is an atlas, gridSquareId will be populated */
+                    search: `?gridSquare=${loaderData.tomograms![0]?.Tomogram?.gridSquareId}` 
+                  }}
                   relative='path'
                   isDisabled={!loaderData.hasAtlas}
+                  leftIcon={<MdOutlineGrain/>}
                 >
-                  <Icon as={MdOutlineGrain} />
+                  View Atlas
                 </Button>
               </Tooltip>
               {window.ENV.REPROCESSING_ENABLED && (

--- a/src/schema/main.d.ts
+++ b/src/schema/main.d.ts
@@ -2456,6 +2456,8 @@ export interface components {
       dataCollectionId: number;
       /** Tomogramid */
       tomogramId: number;
+      /** Grid square ID */
+      gridSquareId?: number | null;
       /** Volumefile */
       volumeFile?: string | null;
       /** Stackfile */


### PR DESCRIPTION
**Summary**:

This displays the right atlas view for SXT, and clicking the "view atlas" button takes you to the correct grid square

**Changes**:
- Display search maps for SXT
- Link to search map in tomogram page

**To test**:
Requires latest version of the backend

- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/nt42520/sessions/37/groups/19334881/tomograms/1, click "view atlas", see if the URL now includes a grid square
